### PR TITLE
fix(tests): scope parity conftest integration marker to own dir

### DIFF
--- a/tests/darnit/parity/test_marker_scope.py
+++ b/tests/darnit/parity/test_marker_scope.py
@@ -1,0 +1,68 @@
+"""Regression guard for issue #395.
+
+Both the tier1 and tier2 conftests contribute a
+``pytest_collection_modifyitems`` hook that adds the ``integration``
+marker. Pytest passes the FULL workspace item list to every hook, so
+without an explicit scope check the hook would silently mark unrelated
+tests -- for example, the ``@pytest.mark.upstream`` CNCF-drift canary
+at ``tests/darnit/context/test_dot_project_upstream.py`` would end up
+selected under ``-m integration`` and block PR CI on unrelated
+upstream churn.
+
+The fix scopes each hook to items under its own conftest directory.
+This test locks that behavior in place by invoking pytest in a
+subprocess with ``-m integration --collect-only`` targeted at
+`test_dot_project_upstream.py` (which carries only the ``upstream``
+marker) and asserting zero tests are collected.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_UPSTREAM_TEST_FILE = (
+    _REPO_ROOT
+    / "tests"
+    / "darnit"
+    / "context"
+    / "test_dot_project_upstream.py"
+)
+
+
+@pytest.mark.unit
+def test_upstream_only_tests_are_not_collected_under_integration():
+    """`-m integration` MUST NOT pick up `@pytest.mark.upstream`-only tests.
+
+    If either parity conftest regresses and re-broadens its
+    modify_items hook, this test will fail because the collect-only
+    output will show more than zero collected items.
+    """
+    if not _UPSTREAM_TEST_FILE.exists():
+        pytest.skip("upstream-marker canary test file not present")
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(_UPSTREAM_TEST_FILE),
+            "-m",
+            "integration",
+            "--collect-only",
+            "-q",
+        ],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    output = proc.stdout + proc.stderr
+    assert "no tests collected" in output, (
+        "Expected `-m integration` to deselect every test in the "
+        "upstream-marker canary file, but pytest reported otherwise:\n\n"
+        + output
+    )

--- a/tests/darnit/parity/tier1/conftest.py
+++ b/tests/darnit/parity/tier1/conftest.py
@@ -27,6 +27,8 @@ from tests.darnit.parity.tier1.comparator import AuditResult
 
 FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
 
+_CONFTEST_DIR = Path(__file__).parent.resolve()
+
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list) -> None:
     """Auto-mark every test in tier1/ as `integration` (PR #370 review fix).
@@ -34,12 +36,23 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list) -> None:
     Parity tests spin up the full harness against a git-initialized
     fixture repo, so they never satisfy the `unit` marker's contract.
     Without an explicit mark, CI's `-m unit / -m integration` split
-    silently deselected the whole suite. This hook applies the mark
-    to every collected item under this conftest.
+    silently deselected the whole suite.
+
+    The `items` list pytest passes here contains EVERY collected test
+    in the workspace, not just items under this conftest. Only mark
+    items whose file path is under ``_CONFTEST_DIR`` -- otherwise this
+    hook silently applies the `integration` marker to unrelated tests
+    (see issue #395: a `@pytest.mark.upstream` canary got collected
+    under `-m integration` because of the previous unscoped iteration).
     """
     integration_mark = pytest.mark.integration
     for item in items:
-        item.add_marker(integration_mark)
+        try:
+            item_path = Path(str(item.fspath)).resolve()
+        except (OSError, ValueError):
+            continue
+        if _CONFTEST_DIR == item_path or _CONFTEST_DIR in item_path.parents:
+            item.add_marker(integration_mark)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/darnit/parity/tier2/conftest.py
+++ b/tests/darnit/parity/tier2/conftest.py
@@ -9,10 +9,27 @@ split silently deselected the entire suite.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
+
+_CONFTEST_DIR = Path(__file__).parent.resolve()
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list) -> None:
+    """Mark tier2 items as `integration`.
+
+    The `items` list pytest passes here contains EVERY collected test
+    in the workspace, not just items under this conftest. Only mark
+    items whose file path is under ``_CONFTEST_DIR`` -- otherwise this
+    hook silently applies the `integration` marker to unrelated tests
+    (see issue #395).
+    """
     integration_mark = pytest.mark.integration
     for item in items:
-        item.add_marker(integration_mark)
+        try:
+            item_path = Path(str(item.fspath)).resolve()
+        except (OSError, ValueError):
+            continue
+        if _CONFTEST_DIR == item_path or _CONFTEST_DIR in item_path.parents:
+            item.add_marker(integration_mark)


### PR DESCRIPTION
## Summary

Fixes issue #395. Both `tests/darnit/parity/tier1/conftest.py` and `tier2/conftest.py` implement `pytest_collection_modifyitems` to auto-mark parity tests as `integration`. The previous implementation iterated the FULL workspace `items` list -- pytest passes every collected test in the workspace to every conftest's hook, not just items under the conftest's own directory. Result: every collected test in the workspace picked up the marker, silently overriding markers the author had chosen explicitly.

Concrete symptom (documented in #395): `-m integration` on CI collected `test_dot_project_upstream.py::TestUpstreamSpecSync::test_upstream_spec_unchanged` even though its class carries `@pytest.mark.upstream`. When CNCF pushed a spec update between PRs, that canary test failed on every open PR regardless of what the PR touched. PR #396 hit it directly and needed a follow-up (#398) to reconcile before merging.

## Fix

Each hook now resolves `Path(item.fspath)` and only applies the marker to items whose file lives under the conftest's own directory:

```python
_CONFTEST_DIR = Path(__file__).parent.resolve()

def pytest_collection_modifyitems(config, items):
    integration_mark = pytest.mark.integration
    for item in items:
        try:
            item_path = Path(str(item.fspath)).resolve()
        except (OSError, ValueError):
            continue
        if _CONFTEST_DIR == item_path or _CONFTEST_DIR in item_path.parents:
            item.add_marker(integration_mark)
```

## Regression guard

`tests/darnit/parity/test_marker_scope.py` subprocess-invokes pytest with `-m integration --collect-only` targeted at the upstream-marker canary file and asserts "no tests collected". If either conftest re-broadens its scope, this test fails immediately.

## Test plan

- [x] `pytest tests/darnit/parity/tier1/ -q` -> 34 pass, 1 skip. Tier 1 tests still pick up `integration` -- fix does not regress the original PR #370 intent.
- [x] `pytest tests/darnit/context/test_dot_project_upstream.py -m integration --collect-only` -> "5 deselected / 0 selected". Upstream marker is now correctly honored.
- [x] `pytest tests/darnit/parity/test_marker_scope.py -v` passes.

Closes #395.