### PR TITLE
feat(audit): include framework + spec version in every audit output format

### DIFF
--- a/packages/darnit-baseline/src/darnit_baseline/formatters/sarif.py
+++ b/packages/darnit-baseline/src/darnit_baseline/formatters/sarif.py
@@ -196,18 +196,28 @@ def generate_sarif_audit(
         )
         sarif_results.append(sarif_result)
 
+    # Issue #350: source spec_version from the framework implementation so
+    # the SARIF report carries provenance that a reader can diff against
+    # the standard version it was evaluated against.
+    from darnit.tools.audit import framework_metadata
+
+    meta = framework_metadata("openssf-baseline")
+    driver: dict[str, Any] = {
+        "name": TOOL_NAME,
+        "version": TOOL_VERSION,
+        "informationUri": TOOL_INFO_URI,
+        "rules": rules,
+    }
+    if meta.get("spec_version"):
+        driver["semanticVersion"] = meta["spec_version"]
+
     # Build the complete SARIF document
     sarif = {
         "$schema": SARIF_SCHEMA,
         "version": SARIF_VERSION,
         "runs": [{
             "tool": {
-                "driver": {
-                    "name": TOOL_NAME,
-                    "version": TOOL_VERSION,
-                    "informationUri": TOOL_INFO_URI,
-                    "rules": rules,
-                }
+                "driver": driver,
             },
             "results": sarif_results,
             "invocations": [{
@@ -218,6 +228,10 @@ def generate_sarif_audit(
                 "owner": audit_result.owner,
                 "repo": audit_result.repo,
                 "level": audit_result.level,
+                "framework": meta.get("name", ""),
+                "framework_version": meta.get("version", ""),
+                "spec_version": meta.get("spec_version", ""),
+                "generated_at": meta.get("generated_at", ""),
                 "compliance": {
                     f"level{lvl}": compliant
                     for lvl, compliant in (audit_result.level_compliance or {}).items()

--- a/packages/darnit-baseline/src/darnit_baseline/tools.py
+++ b/packages/darnit-baseline/src/darnit_baseline/tools.py
@@ -206,6 +206,8 @@ def audit_openssf_baseline(
     elif output_format == "summary":
         # Compact JSON: only id/status/level/details — no evidence or pass_history.
         # ~5-8K vs ~164K for full JSON with 62 controls.
+        from darnit.tools.audit import framework_metadata
+
         compact_results = [
             {
                 "id": r.get("id"),
@@ -216,6 +218,7 @@ def audit_openssf_baseline(
             for r in results
         ]
         output = json.dumps({
+            "metadata": framework_metadata("openssf-baseline"),
             "owner": owner,
             "repo": repo,
             "level": level,
@@ -223,7 +226,10 @@ def audit_openssf_baseline(
             "results": compact_results,
         }, indent=2)
     elif output_format == "json":
+        from darnit.tools.audit import framework_metadata
+
         output = json.dumps({
+            "metadata": framework_metadata("openssf-baseline"),
             "owner": owner,
             "repo": repo,
             "level": level,

--- a/packages/darnit/src/darnit/tools/audit.py
+++ b/packages/darnit/src/darnit/tools/audit.py
@@ -193,6 +193,57 @@ def load_effective_audit_config(local_path: str, framework_name: str | None = No
         return None
 
 
+def framework_metadata(framework_name: str | None) -> dict[str, str]:
+    """Return the framework metadata block for the audit output header (issue #350).
+
+    Every audit output format (markdown, JSON, SARIF, summary) includes
+    this block so a reader knows what implementation + upstream spec
+    version the audit was evaluated against. Without it, a report from
+    ``OSPS v2025.10.10`` is indistinguishable from ``OSPS v2026.02.19``.
+
+    Args:
+        framework_name: Implementation identifier (e.g., "openssf-baseline").
+            When None or the implementation is not installed, returns a
+            best-effort block with the name (or "unknown") and an ISO
+            timestamp -- never raises.
+
+    Returns:
+        Dict with keys:
+        - ``name``: implementation identifier (or "unknown")
+        - ``display_name``: human-readable name
+        - ``version``: implementation version (e.g., "0.1.0")
+        - ``spec_version``: upstream standard version (e.g., "OSPS v2026.02.19")
+        - ``generated_at``: ISO-8601 UTC timestamp
+    """
+    from datetime import UTC, datetime
+
+    generated_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    fallback: dict[str, str] = {
+        "name": framework_name or "unknown",
+        "display_name": "",
+        "version": "",
+        "spec_version": "",
+        "generated_at": generated_at,
+    }
+    if not framework_name:
+        return fallback
+    try:
+        from darnit.core.discovery import get_implementation
+
+        impl = get_implementation(framework_name)
+    except Exception:  # noqa: BLE001
+        return fallback
+    if impl is None:
+        return fallback
+    return {
+        "name": getattr(impl, "name", framework_name) or framework_name,
+        "display_name": getattr(impl, "display_name", "") or "",
+        "version": getattr(impl, "version", "") or "",
+        "spec_version": getattr(impl, "spec_version", "") or "",
+        "generated_at": generated_at,
+    }
+
+
 def get_excluded_control_ids(local_path: str) -> dict[str, str]:
     """Get control IDs that are excluded via user config.
 
@@ -704,9 +755,19 @@ def format_results_markdown(
     Returns:
         Markdown-formatted report
     """
+    meta = framework_metadata(framework_name)
+    header_lines = [f"# {report_title}", ""]
+    if meta.get("display_name") or meta.get("name"):
+        header_lines.append(
+            f"**Framework:** {meta.get('display_name') or meta['name']}"
+            + (f" v{meta['version']}" if meta.get("version") else "")
+        )
+    if meta.get("spec_version"):
+        header_lines.append(f"**Spec Version:** {meta['spec_version']}")
+    if meta.get("generated_at"):
+        header_lines.append(f"**Generated At:** {meta['generated_at']}")
     lines = [
-        f"# {report_title}",
-        "",
+        *header_lines,
         f"**Repository:** {owner}/{repo}",
         f"**Level Assessed:** {level}",
         "",

--- a/tests/darnit/tools/test_framework_metadata.py
+++ b/tests/darnit/tools/test_framework_metadata.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import re
 
-import pytest
-
 
 class TestFrameworkMetadata:
     def test_installed_framework_returns_full_metadata(self):
@@ -93,8 +91,8 @@ class TestMarkdownHeaderIncludesMetadata:
 class TestJsonOutputIncludesMetadata:
     def test_json_output_has_top_level_metadata_block(self, tmp_path, monkeypatch):
         """Every JSON audit output MUST include a top-level `metadata` block."""
-        from unittest.mock import patch
         import json
+        from unittest.mock import patch
 
         # Bypass the actual audit run -- we only care about the JSON shape.
         with patch(

--- a/tests/darnit/tools/test_framework_metadata.py
+++ b/tests/darnit/tools/test_framework_metadata.py
@@ -1,0 +1,125 @@
+"""Tests for `framework_metadata` audit-output header helper (issue #350)."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+
+class TestFrameworkMetadata:
+    def test_installed_framework_returns_full_metadata(self):
+        from darnit.tools.audit import framework_metadata
+
+        meta = framework_metadata("openssf-baseline")
+
+        assert meta["name"] == "openssf-baseline"
+        assert meta["display_name"] == "OpenSSF Baseline"
+        assert meta["version"]  # non-empty
+        assert meta["spec_version"].startswith("OSPS v")
+        # ISO-8601 UTC with Z suffix
+        assert re.match(
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$",
+            meta["generated_at"],
+        )
+
+    def test_none_framework_falls_back_gracefully(self):
+        from darnit.tools.audit import framework_metadata
+
+        meta = framework_metadata(None)
+        assert meta["name"] == "unknown"
+        assert meta["display_name"] == ""
+        assert meta["version"] == ""
+        assert meta["spec_version"] == ""
+        assert meta["generated_at"]
+
+    def test_unknown_framework_uses_name_but_empty_fields(self, monkeypatch):
+        """A framework that isn't registered still yields a metadata block
+        so the audit output header is never missing its shape."""
+        from darnit.tools import audit
+
+        # Force get_implementation to return None (framework not installed).
+        monkeypatch.setattr(
+            "darnit.core.discovery.get_implementation", lambda _: None
+        )
+
+        meta = audit.framework_metadata("does-not-exist")
+        assert meta["name"] == "does-not-exist"
+        assert meta["display_name"] == ""
+        assert meta["version"] == ""
+        assert meta["spec_version"] == ""
+
+    def test_discovery_exception_falls_back_never_raises(self, monkeypatch):
+        """A broken get_implementation() implementation must not crash
+        audit output generation."""
+        from darnit.tools import audit
+
+        def _boom(_):
+            raise RuntimeError("registry corrupted")
+
+        monkeypatch.setattr("darnit.core.discovery.get_implementation", _boom)
+
+        meta = audit.framework_metadata("openssf-baseline")
+        assert meta["name"] == "openssf-baseline"
+        assert meta["display_name"] == ""
+        assert meta["generated_at"]
+
+
+class TestMarkdownHeaderIncludesMetadata:
+    def test_header_lists_framework_spec_and_timestamp(self):
+        from darnit.tools.audit import format_results_markdown
+
+        out = format_results_markdown(
+            owner="acme",
+            repo="widget",
+            results=[],
+            summary={
+                "PASS": 0, "FAIL": 0, "WARN": 0, "PENDING_LLM": 0,
+                "N/A": 0, "ERROR": 0, "total": 0,
+            },
+            compliance={1: True, 2: True, 3: True},
+            level=1,
+            local_path="/tmp/notarealpath",
+            report_title="OpenSSF Baseline Audit Report",
+            framework_name="openssf-baseline",
+        )
+
+        assert "**Framework:** OpenSSF Baseline" in out
+        assert "**Spec Version:** OSPS v" in out
+        assert "**Generated At:**" in out
+        assert "**Repository:** acme/widget" in out
+
+
+class TestJsonOutputIncludesMetadata:
+    def test_json_output_has_top_level_metadata_block(self, tmp_path, monkeypatch):
+        """Every JSON audit output MUST include a top-level `metadata` block."""
+        from unittest.mock import patch
+        import json
+
+        # Bypass the actual audit run -- we only care about the JSON shape.
+        with patch(
+            "darnit.tools.audit.run_sieve_audit",
+            return_value=([], {
+                "PASS": 0, "FAIL": 0, "WARN": 0, "PENDING_LLM": 0,
+                "N/A": 0, "ERROR": 0, "total": 0,
+            }),
+        ), patch(
+            "darnit.core.utils.detect_owner_repo",
+            return_value=("acme", "widget"),
+        ):
+            from darnit_baseline.tools import audit_openssf_baseline
+
+            raw = audit_openssf_baseline(
+                local_path=str(tmp_path),
+                output_format="json",
+                auto_init_config=False,
+                attest=False,
+                prefer_upstream=False,
+            )
+        payload = json.loads(raw)
+        assert "metadata" in payload
+        meta = payload["metadata"]
+        assert meta["name"] == "openssf-baseline"
+        assert meta["display_name"] == "OpenSSF Baseline"
+        assert meta["spec_version"].startswith("OSPS v")
+        assert meta["generated_at"]


### PR DESCRIPTION
## Summary

Closes #350. Adds a small `framework_metadata()` helper in `darnit.tools.audit` that sources the framework's `name`, `display_name`, `version`, and `spec_version` from the installed `ComplianceImplementation` (plus a generation timestamp). Every audit output format now carries this block so a reader can tell what standard version the report was evaluated against without an out-of-band `darnit list` call.

Motivating case (per #350): skill / attestation / dashboard consumers need to diff `OSPS v2025.10.10` verdicts against `OSPS v2026.02.19` verdicts. Pre-fix, that was impossible from the report alone.

## Wire-up

- **Markdown**: three-line header block (Framework, Spec Version, Generated At) inserted between the title and the Repository line.
- **JSON / summary**: top-level `metadata` object alongside `owner`, `repo`, `level`, `summary`, `results`.
- **SARIF**: `runs[].tool.driver.semanticVersion` set to the spec version; `runs[].properties` gains `framework`, `framework_version`, `spec_version`, `generated_at` alongside the existing shape.

## Safety

`framework_metadata` never raises. A missing framework, an uninstalled implementation, or a broken registry all fall back to a best-effort block with the name (or `"unknown"`) and the timestamp -- audit output shape stays stable in every path.

## Test plan

- [x] 6 new tests in `tests/darnit/tools/test_framework_metadata.py`: happy path, `None` framework, uninstalled framework, exception path (registry raises), markdown header includes metadata, JSON output has top-level metadata block.
- [x] `pytest tests/darnit_baseline/formatters/ tests/darnit_baseline/test_integration_e2e.py -q` -> 44 pass (SARIF + integration regression clean).
- [x] Full workspace sweep: `pytest tests/ -q` -> 2874 pass, 25 skip, 0 fail.

## Not in scope

- Does not alter the badge output (badges are pass-count summaries; version metadata would fight the URL-length budget).
- Does not modify the attestation predicate. `generate_attestation_from_results` still writes its own subject/commit shape; wiring `spec_version` there is a separate design decision about attestation schema versioning.

Closes #350.