### PR TITLE
fix(baseline): accept LICENCE spelling and unify LE-01.01/LE-03.01 discover lists

### DIFF
--- a/packages/darnit-baseline/src/darnit_baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/src/darnit_baseline/openssf-baseline.toml
@@ -1709,7 +1709,11 @@ git commit -s -m "Your commit message"
 
 [controls."OSPS-LE-01.01".locator]
 project_path = "legal.license"
-discover = ["LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING"]
+discover = [
+    "LICENSE", "LICENSE.md", "LICENSE.txt",
+    "LICENCE", "LICENCE.md", "LICENCE.txt",
+    "COPYING", "COPYING.md", "COPYING.txt",
+]
 kind = "file"
 
 [[controls."OSPS-LE-01.01".passes]]
@@ -1897,7 +1901,11 @@ help_md = """Add license file to repository.
 
 [controls."OSPS-LE-03.01".locator]
 project_path = "legal.license"
-discover = ["LICENSE", "LICENSE.md", "COPYING"]
+discover = [
+    "LICENSE", "LICENSE.md", "LICENSE.txt",
+    "LICENCE", "LICENCE.md", "LICENCE.txt",
+    "COPYING", "COPYING.md", "COPYING.txt",
+]
 kind = "file"
 
 [[controls."OSPS-LE-03.01".passes]]

--- a/tests/darnit_baseline/controls/test_license_discovery.py
+++ b/tests/darnit_baseline/controls/test_license_discovery.py
@@ -1,0 +1,85 @@
+"""Regression tests for license-file discovery (issues #403, #404).
+
+LE-01.01 and LE-03.01 previously used different `discover` lists and
+neither accepted the British spelling, so a repository shipping `LICENCE`
+failed both controls despite having a valid license file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from darnit.sieve.models import CheckContext, ControlSpec
+from darnit.sieve.orchestrator import SieveOrchestrator
+
+LICENSE_CONTROLS = ("OSPS-LE-01.01", "OSPS-LE-03.01")
+
+MIT_TEXT = """MIT License
+
+Copyright (c) 2026 Example Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction.
+"""
+
+
+def _load_control(control_id: str) -> ControlSpec:
+    from darnit.config.control_loader import control_from_framework
+    from darnit.config.merger import load_framework_by_name
+
+    config = load_framework_by_name("openssf-baseline")
+    return control_from_framework(control_id, config.controls[control_id])
+
+
+def _make_ctx(local_path: Path, control_id: str) -> CheckContext:
+    return CheckContext(
+        owner="test",
+        repo="test-repo",
+        local_path=str(local_path),
+        default_branch="main",
+        control_id=control_id,
+    )
+
+
+@pytest.mark.parametrize("control_id", LICENSE_CONTROLS)
+@pytest.mark.parametrize(
+    "filename",
+    ["LICENSE", "LICENSE.md", "LICENSE.txt", "LICENCE", "LICENCE.md", "LICENCE.txt", "COPYING"],
+)
+def test_license_filename_variants_pass(
+    tmp_path: Path,
+    control_id: str,
+    filename: str,
+) -> None:
+    """Both controls accept US and British spellings and common suffixes."""
+    (tmp_path / filename).write_text(MIT_TEXT, encoding="utf-8")
+
+    control = _load_control(control_id)
+    result = SieveOrchestrator(stop_on_llm=False).verify(control, _make_ctx(tmp_path, control_id))
+
+    assert result.status == "PASS", f"{control_id} failed on {filename}: {result.details}"
+
+
+@pytest.mark.parametrize("control_id", LICENSE_CONTROLS)
+def test_missing_license_still_fails(tmp_path: Path, control_id: str) -> None:
+    """Broadening the list must not make the controls pass on a repo with
+    no license file at all."""
+    (tmp_path / "README.md").write_text("# proj\n", encoding="utf-8")
+
+    control = _load_control(control_id)
+    result = SieveOrchestrator(stop_on_llm=False).verify(control, _make_ctx(tmp_path, control_id))
+
+    assert result.status != "PASS"
+
+
+def test_both_controls_share_one_discover_list() -> None:
+    """#403: LE-01.01 and LE-03.01 must not drift apart again."""
+    from darnit.config.merger import load_framework_by_name
+
+    config = load_framework_by_name("openssf-baseline")
+    lists = [config.controls[c].locator.discover for c in LICENSE_CONTROLS]
+    assert lists[0] == lists[1]
+    assert "LICENCE" in lists[0]


### PR DESCRIPTION
﻿Fixes #404
Fixes #403

## Problem

LE-01.01 and LE-03.01 used different `discover` lists, and neither accepted the British spelling.

tqdm ships `LICENCE` and failed both controls despite having a valid license; remediation then wrote an MIT `LICENSE` alongside the real file, contradicting it. Separately, `LICENSE.txt` was accepted by LE-01.01 but not LE-03.01, so flask passes one and fails the other on the same file.

## Change

Both controls now share one list: LICENSE / LICENCE / COPYING with `.md` and `.txt` variants. #403 and #404 are fixed together because unifying the lists is how the variants get added.

## Verification

Before, on tqdm:

    OSPS-LE-01.01: FAIL - None of the required files found: ['LICENSE', 'LICENSE.md', 'LICENSE.txt', 'COPYING']
    OSPS-LE-03.01: FAIL - None of the required files found: ['LICENSE', 'LICENSE.md', 'COPYING']

After:

    OSPS-LE-01.01: PASS - Required file found: LICENCE
    OSPS-LE-03.01: PASS - Required file found: LICENCE

New `tests/darnit_baseline/controls/test_license_discovery.py` — 17 tests covering each filename variant on both controls, the no-license case (must still not PASS), and list parity between the two controls.

`tests/darnit_baseline` is unchanged at 11 failed / 848 passed before and after on this machine; those 11 are pre-existing Windows path-separator failures unrelated to this change.

## Not included

The remediation gating discussed in #404 — whether a recognized license file should suppress the MIT template entirely — is left for a separate PR, since it is a behaviour change rather than a data fix.
