### PR TITLE
fix(context): honor value_if_fail in detect pipeline (audit reproducibility)

### DIFF
--- a/packages/darnit/src/darnit/config/context_storage.py
+++ b/packages/darnit/src/darnit/config/context_storage.py
@@ -701,7 +701,29 @@ def _run_detect_pipeline(
                         confidence=result.confidence,
                     )
 
-            # INCONCLUSIVE or FAIL — try next handler in pipeline
+            # Non-PASS: apply value_if_fail as a stable fallback if the TOML
+            # author set one. Short-circuits the chain -- subsequent handlers
+            # are not tried. This is the mechanism that makes flaky network
+            # detectors (e.g., `gh release list`) produce a deterministic
+            # false rather than a missing key when they can't conclude.
+            if result.status in (
+                HandlerResultStatus.FAIL,
+                HandlerResultStatus.INCONCLUSIVE,
+                HandlerResultStatus.ERROR,
+            ):
+                value_if_fail = handler_config.get("value_if_fail")
+                if value_if_fail is not None:
+                    return ContextValue.auto_detected(
+                        value=value_if_fail,
+                        method=f"detect_pipeline:{invocation.handler}:fail_fallback",
+                        # Handlers that FAIL / ERROR / INCONCLUSIVE frequently
+                        # leave confidence unset (None); fall back to
+                        # auto_detected's own default rather than passing None
+                        # into a numeric comparison.
+                        confidence=result.confidence if result.confidence is not None else 0.8,
+                    )
+
+            # No value_if_fail -- try next handler in pipeline
 
     except ImportError:
         logger.debug("Sieve handler registry not available for context detection")

--- a/tests/darnit/config/test_context_storage.py
+++ b/tests/darnit/config/test_context_storage.py
@@ -457,6 +457,101 @@ class TestRunDetectPipelineHasReleases:
         result = _run_detect_pipeline("has_releases", pipeline, str(tmp_path), "owner", "repo")
         assert result is None
 
+    def test_value_if_fail_fires_on_last_detector_fail(self, tmp_path: Path) -> None:
+        """When the last detector fails and has value_if_fail, it fires.
+
+        Reproducibility fix: a flaky `gh release list` (non-zero exit, empty
+        stdout with an expr, or ERROR) previously left the key missing from
+        context, which caused when-clause matching to skip controls
+        nondeterministically across audit runs. With value_if_fail wired,
+        the failure resolves to a stable false.
+        """
+        pipeline = [
+            self._make_invocation(handler="file_exists", files=[".github/workflows/release*"], value_if_pass=True),
+            self._make_invocation(handler="file_exists", files=["CHANGELOG.md", "CHANGELOG"], value_if_pass=True),
+            self._make_invocation(
+                handler="exec",
+                command=["false"],  # deterministic non-zero exit
+                pass_exit_codes=[0],
+                value_if_pass=True,
+                value_if_fail=False,
+            ),
+        ]
+        result = _run_detect_pipeline("has_releases", pipeline, str(tmp_path), "owner", "repo")
+        assert result is not None
+        assert result.value is False
+        assert "fail_fallback" in result.detection_method
+
+    def test_value_if_fail_fires_when_expr_evaluates_false(self, tmp_path: Path) -> None:
+        """PASS-with-expr-false (INCONCLUSIVE post-CEL) also triggers value_if_fail.
+
+        This is the "gh release list succeeded but returned empty stdout"
+        case -- the repo genuinely has no releases. Pre-fix: INCONCLUSIVE
+        propagated to end-of-chain and returned None. Post-fix: value_if_fail
+        stabilises this to false.
+        """
+        with patch("darnit.sieve.builtin_handlers.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            pipeline = [
+                self._make_invocation(
+                    handler="exec",
+                    command=["gh", "release", "list", "--repo", "$OWNER/$REPO", "--limit", "1"],
+                    pass_exit_codes=[0],
+                    expr='output.stdout != ""',
+                    value_if_pass=True,
+                    value_if_fail=False,
+                ),
+            ]
+            result = _run_detect_pipeline("has_releases", pipeline, str(tmp_path), "owner", "repo")
+        assert result is not None
+        assert result.value is False
+        assert "fail_fallback" in result.detection_method
+
+    def test_value_if_fail_short_circuits_middle_detector(self, tmp_path: Path) -> None:
+        """value_if_fail on a middle detector fires and skips subsequent detectors.
+
+        Documents the short-circuit semantic: if a TOML author sets
+        value_if_fail on a non-last detector, later detectors are not tried
+        when that detector fails. If a chain-level fallback is desired
+        instead, put value_if_fail on the last detector.
+        """
+        (tmp_path / "CHANGELOG.md").write_text("# changelog\n")
+        pipeline = [
+            self._make_invocation(
+                handler="exec",
+                command=["false"],
+                pass_exit_codes=[0],
+                value_if_pass=True,
+                value_if_fail=False,
+            ),
+            # This later detector WOULD pass but should not be reached.
+            self._make_invocation(handler="file_exists", files=["CHANGELOG.md"], value_if_pass=True),
+        ]
+        result = _run_detect_pipeline("has_releases", pipeline, str(tmp_path), "owner", "repo")
+        assert result is not None
+        assert result.value is False, "short-circuit: middle detector's value_if_fail must fire"
+
+    def test_earlier_pass_still_wins_over_later_value_if_fail(self, tmp_path: Path) -> None:
+        """PASS-first-wins semantics preserved: earlier detector's success skips fail-fallback.
+
+        Guards against a regression where the fix accidentally makes
+        value_if_fail from later detectors override earlier successes.
+        """
+        (tmp_path / "CHANGELOG.md").write_text("# changelog\n")
+        pipeline = [
+            self._make_invocation(handler="file_exists", files=["CHANGELOG.md"], value_if_pass=True),
+            self._make_invocation(
+                handler="exec",
+                command=["false"],
+                pass_exit_codes=[0],
+                value_if_pass=True,
+                value_if_fail=False,
+            ),
+        ]
+        result = _run_detect_pipeline("has_releases", pipeline, str(tmp_path), "owner", "repo")
+        assert result is not None
+        assert result.value is True
+
 
 class TestRunDetectPipelinePlatform:
     """Tests for platform detect pipeline (FR-3)."""


### PR DESCRIPTION
## Summary

Context detect chains that authored `value_if_fail = <default>` on a
network-flaky handler were silently ignoring it -- `_run_detect_pipeline`
only ever read `value_if_pass`. On any FAIL / INCONCLUSIVE / ERROR
result the runner just proceeded to the next handler, and if the flaky
handler was last in the chain, the whole function returned `None`
(key missing from context).

Concrete example is `openssf-baseline.toml:339-344` -- the
`has_releases` chain's final detector, `gh release list --limit 1`, is
declared as `value_if_pass = true, value_if_fail = false`. The
`value_if_fail = false` never fired.

## User-visible effect (surfaced by @Marc-cn while testing #369)

Same commit, same repo, back-to-back `darnit audit` runs produced
different PASS/WARN counts because `has_releases` oscillated between
`true` (when the `gh` call succeeded) and missing (rate-limited /
network error / empty stdout). `when = { has_releases = true }` then
either matched or fail-to-matched depending on the run, causing
LE-03.02 (and controls that inherit via `inferred_from`) to flip
verdict across runs.

10 consecutive runs on tqdm @ 96f2e60, cache cleared between each,
produced 6x (31 PASS / 15 FAIL / 14 WARN) and 4x (32 / 15 / 13).

## Fix

After the CEL post-step application in `_run_detect_pipeline`, on
non-PASS status check the handler config for `value_if_fail`. If set,
apply it and short-circuit the chain. Exception path unchanged --
exceptions bubble to the outer catch and return None; those are
safety-net paths, not the flakiness surface.

**Bonus normalization**: handler `confidence` is `float | None`; the
existing PASS path was silently passing None into
`ContextValue.auto_detected(confidence=...)`, which does a `>=`
compare and would crash for any handler returning PASS with unset
confidence. Normalized on the fail-fallback path to 0.8 (the
auto_detected function's own default).

## Test plan

- [X] `test_value_if_fail_fires_on_last_detector_fail` -- primary
  reproducibility case.
- [X] `test_value_if_fail_fires_when_expr_evaluates_false` -- gh
  succeeds but returns empty stdout -> expr false -> INCONCLUSIVE
  post-CEL -> value_if_fail fires.
- [X] `test_value_if_fail_short_circuits_middle_detector` --
  documents chain-short-circuit semantic.
- [X] `test_earlier_pass_still_wins_over_later_value_if_fail` --
  regression guard for PASS-first-wins semantics.
- [X] Full framework suite: **1904 passed** (was 1900; +4 new tests).
- [X] `ruff check` clean on touched files.

## Follow-up (separate issue, not this PR)

@Marc-cn also flagged that `inferred_from` PASSes inherit `dispositive`
authority (post feature 025 / RFC-0001 Stage 1), so LE-03.02 can be
reported as a dispositive PASS in a run where nothing about LE-03.02
was actually checked. That's a real design question but scoped
separately from this reproducibility fix.