### PR TITLE
fix: register plugin sieve handlers and stabilize control order (#427, #428)

### DIFF
--- a/packages/darnit/src/darnit/cli.py
+++ b/packages/darnit/src/darnit/cli.py
@@ -237,6 +237,14 @@ def cmd_audit(args: argparse.Namespace) -> int:
         controls=controls,
         apply_user_config=False,  # CLI already applied filters above
         stop_on_llm=True,
+        # Issue #427: the framework name has to reach the audit driver, not
+        # just the control loader above. Without it the driver cannot
+        # register the framework's plugin sieve handlers, and every control
+        # referencing one falls through to `manual` with a WARN that reads
+        # like "could not verify" rather than "handler never loaded".
+        # openssf-baseline masked this because its controls use only
+        # built-in handlers.
+        framework_name=config.framework_name,
     )
 
     # Output results

--- a/packages/darnit/src/darnit/config/merger.py
+++ b/packages/darnit/src/darnit/config/merger.py
@@ -420,10 +420,16 @@ def merge_configs(
         effective.cache_ttl = user.settings.cache_ttl
         effective.timeout = user.settings.timeout
 
-    # Collect all control IDs
-    all_control_ids: set[str] = set(framework.controls.keys())
-    if user:
-        all_control_ids.update(user.controls.keys())
+    # Collect all control IDs, preserving declaration order (issue #428).
+    # A `set` here randomized iteration order per PYTHONHASHSEED, so the
+    # same repo audited twice listed its controls differently. `dict` keys
+    # already carry TOML declaration order, which groups controls by domain
+    # the way the framework author wrote them -- so dedup through
+    # `dict.fromkeys` rather than sorting, which would discard that grouping.
+    # Framework controls first, then any user-only additions.
+    all_control_ids: list[str] = list(
+        dict.fromkeys([*framework.controls, *(user.controls if user else [])])
+    )
 
     # Merge each control
     for control_id in all_control_ids:

--- a/packages/darnit/src/darnit/core/discovery.py
+++ b/packages/darnit/src/darnit/core/discovery.py
@@ -97,6 +97,70 @@ def get_implementation(name: str) -> ComplianceImplementation | None:
     return implementations.get(name)
 
 
+def register_implementation_handlers(framework_name: str | None) -> bool:
+    """Register a framework implementation's custom sieve handlers.
+
+    Plugin packages that ship Python sieve handlers (as opposed to controls
+    built only from the built-in handlers) expose them through
+    ``register_handlers()``. Until that runs, TOML controls referencing a
+    plugin handler by short name resolve to nothing and the orchestrator
+    falls through to `manual`, producing a WARN that looks like "we could
+    not verify" rather than "this handler was never loaded" (issue #427).
+
+    Idempotent: the underlying registry overwrites by name, and
+    implementations are cached, so repeat calls are cheap and safe.
+
+    Args:
+        framework_name: Implementation name (e.g. ``"reproducibility"``).
+            ``None`` is accepted and is a no-op, so callers that may not
+            have resolved a framework do not need to guard.
+
+    Returns:
+        True if handlers were registered, False if there was nothing to do
+        (no framework name, no such implementation, or the implementation
+        does not expose ``register_handlers``).
+    """
+    if not framework_name:
+        return False
+
+    impl = get_implementation(framework_name)
+    if impl is None:
+        logger.debug("No implementation found for '%s'", framework_name)
+        return False
+
+    # Two method names are in use across in-tree plugins:
+    #   register_handlers       -- documented in CLAUDE.md; darnit-baseline
+    #   register_sieve_handlers -- darnit-gittuf, darnit-reproducibility
+    # Those two work today only because their `register()` entry point calls
+    # register_sieve_handlers() during discovery. That is a side channel, not
+    # the protocol: discovery results are cached, so any caller that warmed
+    # the cache earlier in the process leaves the handlers unregistered and
+    # every plugin control silently falls through to `manual`. Accepting both
+    # names here makes registration explicit and cache-independent.
+    # hasattr per Constitution Principle I: missing methods degrade, never crash.
+    method = None
+    for name in ("register_handlers", "register_sieve_handlers"):
+        if hasattr(impl, name):
+            method = getattr(impl, name)
+            break
+    if method is None:
+        return False
+
+    try:
+        method()
+    except Exception as err:  # noqa: BLE001 - a bad plugin must not kill the audit
+        logger.warning(
+            "Failed to register handlers for '%s': %s: %s",
+            framework_name,
+            type(err).__name__,
+            err,
+        )
+        return False
+
+    logger.debug("Registered handlers for '%s'", framework_name)
+    return True
+
+
 def clear_cache() -> None:
     """Clear the implementation cache.
 
@@ -107,7 +171,8 @@ def clear_cache() -> None:
 
 
 __all__ = [
+    "clear_cache",
     "discover_implementations",
     "get_implementation",
-    "clear_cache",
+    "register_implementation_handlers",
 ]

--- a/packages/darnit/src/darnit/tools/audit.py
+++ b/packages/darnit/src/darnit/tools/audit.py
@@ -475,6 +475,16 @@ def run_sieve_audit(
         except Exception:
             pass
 
+    # Register the framework's custom sieve handlers (issue #427). This runs
+    # regardless of whether `controls` was supplied: a caller passing
+    # pre-loaded ControlSpecs still needs the handlers those specs reference
+    # to exist in the registry. Previously this happened only in the MCP
+    # server factory, so plugin-provided handlers were missing from every
+    # other entry point and their controls silently fell through to `manual`.
+    from darnit.core.discovery import register_implementation_handlers
+
+    register_implementation_handlers(resolved_fw)
+
     # Resolve controls: use provided list or load from TOML/registry
     if controls is not None:
         all_controls = list(controls)

--- a/tests/darnit/test_plugin_handler_registration.py
+++ b/tests/darnit/test_plugin_handler_registration.py
@@ -1,0 +1,175 @@
+"""Plugin sieve-handler registration and control ordering.
+
+Covers issues #427 and #428, both reported against the
+`darnit-reproducibility` plugin but rooted in the framework.
+
+#427: plugin-provided sieve handlers never reached the registry outside
+the MCP server path, so every control referencing one fell through to
+`manual` and reported WARN. The WARN text ("Could not automatically
+verify - manual verification required") is indistinguishable from a
+control that genuinely could not be determined, which is what made this
+hard to spot -- the audit looked like it ran.
+
+#428: control iteration order came from a `set`, so the same repo
+audited twice listed its controls differently.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from darnit.core.discovery import register_implementation_handlers
+from darnit.sieve.handler_registry import get_sieve_handler_registry
+
+# Handlers shipped by darnit-reproducibility. It is the in-tree plugin that
+# exercises the `register_sieve_handlers` spelling (see the naming note in
+# TestProtocolMethodNaming below).
+_REPRO_HANDLERS = (
+    "repro_deps_pinned",
+    "repro_build_env_declared",
+    "repro_hermetic_build",
+    "repro_provenance_exists",
+    "repro_bit_for_bit",
+)
+
+
+class TestRegisterImplementationHandlers:
+    """#427: registration must be explicit, not a side effect of discovery."""
+
+    @pytest.mark.unit
+    def test_registers_reproducibility_handlers(self) -> None:
+        assert register_implementation_handlers("reproducibility") is True
+
+        registry = get_sieve_handler_registry()
+        missing = [h for h in _REPRO_HANDLERS if registry.get(h) is None]
+        assert missing == [], f"handlers absent from registry: {missing}"
+
+    @pytest.mark.unit
+    def test_registers_baseline_handlers(self) -> None:
+        """darnit-baseline uses the other spelling; both must work."""
+        assert register_implementation_handlers("openssf-baseline") is True
+
+    @pytest.mark.unit
+    def test_works_when_discovery_cache_is_already_warm(self) -> None:
+        """The regression that made #427 intermittent.
+
+        `discover_implementations()` is cached, and the plugins that
+        self-register do so from their `register()` entry point -- which
+        runs once, during the first discovery. Any caller that warmed the
+        cache earlier in the process therefore left handlers unregistered.
+        That timing dependence is why the bug presented as "3 of 5
+        handlers missing" on one run and "5 of 5" on the next.
+
+        Registration must not depend on cache state.
+        """
+        from darnit.core.discovery import discover_implementations
+
+        discover_implementations()  # warm the cache first
+        assert register_implementation_handlers("reproducibility") is True
+
+        registry = get_sieve_handler_registry()
+        assert all(registry.get(h) is not None for h in _REPRO_HANDLERS)
+
+    @pytest.mark.unit
+    def test_none_framework_is_a_noop(self) -> None:
+        """Callers that never resolved a framework must not need a guard."""
+        assert register_implementation_handlers(None) is False
+
+    @pytest.mark.unit
+    def test_unknown_framework_is_a_noop(self) -> None:
+        assert register_implementation_handlers("no-such-framework") is False
+
+    @pytest.mark.unit
+    def test_is_idempotent(self) -> None:
+        """Called once per audit; repeat calls must not raise."""
+        assert register_implementation_handlers("reproducibility") is True
+        assert register_implementation_handlers("reproducibility") is True
+
+    @pytest.mark.unit
+    def test_plugin_exception_is_contained(self) -> None:
+        """A broken plugin degrades the audit; it must not abort it.
+
+        Constitution Principle I: missing or failing implementations
+        degrade gracefully rather than crashing the framework.
+        """
+        from unittest.mock import MagicMock, patch
+
+        broken = MagicMock()
+        broken.register_handlers.side_effect = RuntimeError("plugin is broken")
+
+        with patch("darnit.core.discovery.get_implementation", return_value=broken):
+            assert register_implementation_handlers("anything") is False
+
+
+class TestProtocolMethodNaming:
+    """Both in-tree spellings of the registration method must be honored.
+
+    `CLAUDE.md` documents `register_handlers()`, and darnit-baseline
+    implements it. darnit-gittuf and darnit-reproducibility implement
+    `register_sieve_handlers()` instead. Until those converge, the
+    framework accepts either -- otherwise two of four in-tree plugins
+    register nothing.
+
+    Reconciling the plugins onto one name is tracked separately; this
+    test pins current behavior so the tolerance is deliberate and
+    visible rather than accidental.
+    """
+
+    @pytest.mark.unit
+    def test_accepts_register_handlers_spelling(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        impl = MagicMock(spec=["register_handlers"])
+        with patch("darnit.core.discovery.get_implementation", return_value=impl):
+            assert register_implementation_handlers("x") is True
+        impl.register_handlers.assert_called_once()
+
+    @pytest.mark.unit
+    def test_accepts_register_sieve_handlers_spelling(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        impl = MagicMock(spec=["register_sieve_handlers"])
+        with patch("darnit.core.discovery.get_implementation", return_value=impl):
+            assert register_implementation_handlers("x") is True
+        impl.register_sieve_handlers.assert_called_once()
+
+    @pytest.mark.unit
+    def test_implementation_with_neither_is_a_noop(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        impl = MagicMock(spec=["name"])
+        with patch("darnit.core.discovery.get_implementation", return_value=impl):
+            assert register_implementation_handlers("x") is False
+
+
+class TestControlOrderDeterminism:
+    """#428: merged control order must be stable across runs."""
+
+    def _merge(self):
+        from darnit.config.merger import load_effective_config_by_name
+
+        return load_effective_config_by_name("openssf-baseline", repo_path=None)
+
+    @pytest.mark.unit
+    def test_control_order_is_stable_across_merges(self) -> None:
+        """A `set` here randomized order per PYTHONHASHSEED."""
+        first = list(self._merge().controls.keys())
+        for _ in range(5):
+            assert list(self._merge().controls.keys()) == first
+
+    @pytest.mark.unit
+    def test_order_follows_toml_declaration_not_alphabetical(self) -> None:
+        """Declaration order groups controls by domain the way the
+        framework author wrote them. Sorting would have been stable too,
+        but would discard that grouping.
+        """
+        ids = list(self._merge().controls.keys())
+        assert ids != sorted(ids), (
+            "control order is alphabetical; expected TOML declaration order"
+        )
+
+    @pytest.mark.unit
+    def test_no_duplicate_control_ids_after_merge(self) -> None:
+        """Guards the set -> list change: dedup must still happen."""
+        ids = list(self._merge().controls.keys())
+        assert len(ids) == len(set(ids))


### PR DESCRIPTION
Closes #427. Closes #428.

Both reported by @Jaydeep869 against `darnit-reproducibility`; both root
causes are in the framework. Thanks for the detailed reports -- the
reproduction steps made these fast to confirm.

## #427 -- plugin handlers never registered outside the MCP path

`darnit audit --framework reproducibility` emitted `handler
'repro_deps_pinned' not found in registry` for all five of the plugin's
controls, which then fell through to `manual` and reported WARN. The
WARN text is "Could not automatically verify - manual verification
required" -- indistinguishable from a control that genuinely could not
be determined. That is why this read as working software rather than a
broken plugin.

Three separate defects, all of which had to be fixed:

**1. The framework name never reached the audit driver.** `cmd_audit`
resolved the framework for loading controls but did not pass
`framework_name` to `run_sieve_audit`, so `resolved_fw` was `None` and
every framework-scoped registration no-opped. openssf-baseline masked
this because its controls use only built-in handlers, which need no
plugin registration.

**2. Handler registration lived only in the MCP server.**
`impl.register_handlers()` was called in exactly one place:
`server/factory.py`. Added `core.discovery.register_implementation_handlers()`
and call it from `run_sieve_audit`, the shared driver both the CLI and
the MCP audit tool go through. It runs regardless of whether `controls`
was supplied, since a caller passing pre-loaded specs still needs the
handlers those specs reference.

**3. Two in-tree plugins use a different method name.**
`darnit-gittuf` and `darnit-reproducibility` implement
`register_sieve_handlers()`, not the `register_handlers()` that
`CLAUDE.md` documents and `darnit-baseline` implements. They worked
only because their `register()` entry point self-registers during
discovery -- and discovery is cached, so any caller that warmed the
cache earlier in the process left the handlers unregistered.

That cache dependence is what made the bug look intermittent: mid-fix I
saw 3-of-5 handlers missing on one run and 5-of-5 on the next, from the
same code. The new helper accepts either spelling, so registration is
explicit and cache-independent.

> A note on the proposed fix in the issue: adding
> `discover_implementations()` to `cmd_audit` addresses the symptom but
> not the cause. Discovery does not register handlers -- nothing in
> `core/discovery.py` did before this change. It appeared to work only
> by re-firing the `register()` side channel described above, which is
> exactly the cache-dependent path. Good diagnosis of the area; the
> mechanism turned out to be one layer down.

Reconciling the two method names across plugins is deliberately **not**
in this PR -- it touches three packages and deserves its own change.
The tolerance is pinned by tests (`TestProtocolMethodNaming`) so it
stays visible rather than becoming accidental convention. Happy to file
that as a follow-up.

## #428 -- non-deterministic control order

`merge_configs` collected control IDs into a `set`, so iteration order
was randomized per `PYTHONHASHSEED`. Five consecutive runs on an
unchanged repo produced five different orderings, exactly as reported.

Deduped through `dict.fromkeys` instead of sorting. `dict` keys already
carry TOML declaration order, which groups controls by domain the way
the framework author wrote them; `sorted()` would have been stable too
but would have discarded that grouping.

This is the same class as #418 (Determinism Tier 1) and a gap that
survey missed -- it covered filesystem iteration but not set iteration
in config merging.

## Verification

| | Before | After |
|---|---|---|
| Handlers missing | 5 of 5 | 0 of 5, across 3 runs |
| Control order | 5 orderings in 5 runs | stable, declaration order |

RE-01.01 now returns a real verdict via CLI for the first time:

```
x RE-01.01: FAIL - Dependency manifests found but no lock files: requirements.txt (pip requirements)
```

(That verdict on an exactly-pinned `numpy==1.26.4` also reproduces
#429, which is untouched here.)

## Test plan

- [X] 13 new tests in `tests/darnit/test_plugin_handler_registration.py`,
  including the warm-cache case that made #427 intermittent and both
  method-name spellings.
- [X] Full suite: **2918 passed**, 14 skipped.
- [X] `ruff check` clean, `validate_sync.py` passes.
- [X] Manually verified against a fixture repo across repeated runs.

## Process note

I found #427 partly because my own local test command was wrong:
`--ignore=tests/darnit/parity` skips parity tier 1, which CI runs.
The correct local invocation is `--ignore=tests/darnit/parity/tier2` --
tier 2 is manual-dispatch and needs API keys; tier 1 runs on every PR.
Worth knowing for anyone else running the suite locally.